### PR TITLE
Fix GF-45028

### DIFF
--- a/assets/cordova-js-2.7.0/cordova.webos.js
+++ b/assets/cordova-js-2.7.0/cordova.webos.js
@@ -224,13 +224,11 @@ var cordova = {
               documentEventHandlers[type].fire(evt);
             }
             else {
-              setTimeout(function() {
-                  // Fire deviceready on listeners that were registered before cordova.js was loaded.
-                  if (type == 'deviceready') {
-                      document.dispatchEvent(evt);
-                  }
-                  documentEventHandlers[type].fire(evt);
-              }, 0);
+              // Fire deviceready on listeners that were registered before cordova.js was loaded.
+              if (type == 'deviceready') {
+                  document.dispatchEvent(evt);
+              }
+              documentEventHandlers[type].fire(evt);
             }
         } else {
             document.dispatchEvent(evt);


### PR DESCRIPTION
GF-45028 : onpause event is not sent when enyo app changed to background status.

Not only pause event, all events should propagate when the app went to background status.

Currently, setTimeout block is pending when the app went to background status, So, setTimeout is removed.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
